### PR TITLE
Support center home - header restructured and logo link corrected

### DIFF
--- a/include/client/footer.inc.php
+++ b/include/client/footer.inc.php
@@ -147,9 +147,9 @@
                     </a>
                 </div>
                 <div style="display: flex; align-items: center; gap: 1rem;">
-                    <a href="https://tgdex.telangana.gov.in/" style="color: #374151; text-decoration: none; font-size: 14px; font-weight: 400;">Privacy Policy</a>
+                    <a href="https://tgdex.telangana.gov.in/privacy-policy" style="color: #374151; text-decoration: none; font-size: 14px; font-weight: 400;">Privacy Policy</a>
                     <span style="color: #9ca3af;">|</span>
-                    <a href="https://tgdex.telangana.gov.in/" style="color: #374151; text-decoration: none; font-size: 14px; font-weight: 400;">Terms of Service</a>
+                    <a href="https://tgdex.telangana.gov.in/terms-of-service" style="color: #374151; text-decoration: none; font-size: 14px; font-weight: 400;">Terms of Service</a>
                 </div>
             </div>
 

--- a/include/client/header.inc.php
+++ b/include/client/header.inc.php
@@ -235,7 +235,7 @@ if (($lang = Internationalization::getCurrentLanguage())) {
                         } ?>
                     </p>
                 </div>
-                <a class="pull-left" id="logo" href="<?php echo ROOT_PATH; ?>index.php"
+                <a class="pull-left" id="logo" href="https://tgdex.telangana.gov.in/"
                     title="<?php echo __('Support Center'); ?>">
                     <span class="valign-helper"></span>
                     <img src="<?php echo ROOT_PATH; ?>logo.php" border=0 alt="<?php

--- a/include/client/header.inc.php
+++ b/include/client/header.inc.php
@@ -161,7 +161,7 @@ if (($lang = Internationalization::getCurrentLanguage())) {
 
                             $initials = strtoupper(substr($thisclient->getName(), 0, 1) . (strpos($thisclient->getName(), ' ') !== false ? substr($thisclient->getName(), strpos($thisclient->getName(), ' ') + 1, 1) : ''));
 
-                            echo '<a href="' . ROOT_PATH . 'profile.php" style="
+                            echo '<a style="
     display: inline-flex;
     justify-content: center;
     align-items: center;
@@ -175,6 +175,7 @@ if (($lang = Internationalization::getCurrentLanguage())) {
     margin: 0 5px;
     text-transform: uppercase;
     text-decoration: none;
+    cursor: default;
                         ">' . Format::htmlchars($initials) . '</a>';
                         } elseif ($nav) {
                             if ($cfg->getClientRegistrationMode() != 'disabled') {

--- a/index.php
+++ b/index.php
@@ -140,14 +140,13 @@ require(CLIENTINC_DIR . 'header.inc.php');
             <!-- Right: AI City -->
             <div style="
                 width: 70px;
-                height: 55px;
                 border-radius: 8px;
                 display: flex;
                 align-items: center;
                 justify-content: center;
                 flex-shrink: 0;
             ">
-                <img src="/osTicket/assets/default/images/AI-CITY-Logo.svg">
+                <img src="/osTicket/assets/default/images/AI-CITY-Logo.svg" style="width: 80px">
             </div>
         </div>
 

--- a/index.php
+++ b/index.php
@@ -27,7 +27,7 @@ require(CLIENTINC_DIR . 'header.inc.php');
     width: 100%;
     background: #ffffff;
     border-bottom: 1px solid #e0e0e0;
-    padding: 15px 20px;
+    padding: 0 20px 20px 0 !important;
     box-sizing: border-box;
     position: relative;
     z-index: 1000;
@@ -35,8 +35,8 @@ require(CLIENTINC_DIR . 'header.inc.php');
     overflow: hidden;
 ">
     <div style="
-        max-width: 1200px;
-        margin: 0 auto;
+        max-width: 100%;
+        /* margin: 0 auto; */
         display: flex;
         flex-direction: column;
         gap: 15px;
@@ -52,7 +52,7 @@ require(CLIENTINC_DIR . 'header.inc.php');
             <!-- Left: Seal + Ministers -->
             <div style="display: flex; align-items: center; gap: 15px; flex-wrap: wrap;">
                 <!-- Government Seal -->
-                <div style="width: 50px; height: 50px; flex-shrink: 0;">
+                <div style="width: 80px; height: 80px; flex-shrink: 0;">
                     <img src="/osTicket/assets/default/images/TelenganaGovt-logo.svg" style="width: 100%; height: 100%;">
                 </div>
 
@@ -62,14 +62,15 @@ require(CLIENTINC_DIR . 'header.inc.php');
                     align-items: center;
                     gap: 10px;
                     background: #ffffff;
-                    padding: 10px 20px;
-                    border-radius: 35px;
+                    padding: 0.25rem 0.5rem;
+                    padding-right: 3rem;
+                    border-radius: 40px;
                     border: 1px solid #d8b167;
                     white-space: nowrap;
                 ">
                     <div style="
-                        width: 60px;
-                        height: 60px;
+                        width: 72px;
+                        height: 72px;
                         border-radius: 50%;
                         overflow: hidden;
                         border: 2px solid #d8b167;
@@ -79,14 +80,14 @@ require(CLIENTINC_DIR . 'header.inc.php');
                     </div>
                     <div>
                         <div style="
-                            font-size: 14px;
+                            font-size: 1rem;
                             color: #000;
                             font-weight: 700;
                             margin: 0 0 2px 0;
                             line-height: 1;
                         ">Hon'ble Chief Minister</div>
                         <div style="
-                            font-size: 13px;
+                            font-size: 1rem;
                             color: #333;
                             margin: 0;
                             font-weight: 400;
@@ -101,14 +102,15 @@ require(CLIENTINC_DIR . 'header.inc.php');
                     align-items: center;
                     gap: 10px;
                     background: #ffffff;
-                    padding: 10px 20px;
-                    border-radius: 35px;
+                    padding: 0.25rem 0.5rem;
+                    padding-right: 5rem;
+                    border-radius: 40px;
                     border: 1px solid #d8b167;
                     white-space: nowrap;
                 ">
                     <div style="
-                        width: 60px;
-                        height: 60px;
+                        width: 72px;
+                        height: 72px;
                         border-radius: 50%;
                         overflow: hidden;
                         border: 2px solid #d8b167;
@@ -118,14 +120,14 @@ require(CLIENTINC_DIR . 'header.inc.php');
                     </div>
                     <div>
                         <div style="
-                            font-size: 14px;
+                            font-size: 1rem;
                             color: #000;
                             font-weight: 700;
                             margin: 0 0 2px 0;
                             line-height: 1;
                         ">Hon'ble IT Minister</div>
                         <div style="
-                            font-size: 13px;
+                            font-size: 1rem;
                             color: #333;
                             margin: 0;
                             font-weight: 400;
@@ -161,10 +163,11 @@ require(CLIENTINC_DIR . 'header.inc.php');
         ">
             <img src="/osTicket/assets/default/images/logo.png" style="height: 46px;">
             <div style="
-                font-size: 36px;
-                color: #333;
-                font-weight: 500;
+                font-size: 52px;
+                color: #212529;
+                font-weight: 400;
                 margin-left: 5px;
+                padding-bottom: 0.6rem
             ">Telangana Data Exchange</div>
         </div>
 


### PR DESCRIPTION
1. The common header has a TGDex logo and it redirects to the main TGDex site instead of the homepage of osTicket as requested. 
2. The header specific to homepage (support center home) has been restructured to match the TGDex website.
3. The "Privacy policy" and "Terms of service" links in the footer (bottom-right) have been updated.
4. Green circle on top right displaying Initials of user after sign-in no longer links to profile.php.